### PR TITLE
tar renamer for regex parsing and replacement of tar files

### DIFF
--- a/bin/autobidsProcess
+++ b/bin/autobidsProcess
@@ -254,7 +254,7 @@ mkdir -p $INCOMING_LOG_DIR
 
 
 #if renamer enabled, then copy tarfiles to INCOMING_BIDS_DIR with new names
-if [ -n $RENAMER_PARSE_PATIENTNAME -a -n $RENAMER_FORMAT_STRING ]
+if [ -n "$RENAMER_PARSE_PATIENTNAME" -a -n "$RENAMER_FORMAT_STRING" ]
 then
   renamer_opts="--in_parse $RENAMER_PARSE_PATIENTNAME --out_reformat $RENAMER_FORMAT_STRING"
   if [ -n "$RENAMER_DEFAULT_SESSION" ]

--- a/bin/autobidsProcess
+++ b/bin/autobidsProcess
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+execpath=`dirname $0`
+execpath=`realpath $execpath`
 
 #this can be overriden in study_cfg files
 TAR2BIDS_IMG=docker://khanlab/tar2bids:latest
@@ -158,6 +160,7 @@ study_cfg=`realpath $study_cfg`
 source $study_cfg
 
 
+
 #add checks here to ensure all required variables are set:
 if [ -n "$CUSTOM_BIDS_DIR" ]
 then
@@ -248,6 +251,27 @@ INCOMING_LOG_DIR=$BIDS_DIR/bids/code/autobids_${INCOMING_ID}
 
 mkdir -p $INCOMING_BIDS_DIR
 mkdir -p $INCOMING_LOG_DIR
+
+
+#if renamer enabled, then copy tarfiles to INCOMING_BIDS_DIR with new names
+if [ -n $RENAMER_PARSE_PATIENTNAME -a -n $RENAMER_FORMAT_STRING ]
+then
+  renamer_opts="--in_parse $RENAMER_PARSE_PATIENTNAME --out_reformat $RENAMER_FORMAT_STRING"
+  if [ -n "$RENAMER_DEFAULT_SESSION" ]
+  then
+      renamer_opts="$renamer_opts --default_session $RENAMER_DEFAULT_SESSION"
+  fi
+    
+  renamed_tars=""
+  for tar in $in_tar
+  do
+      renamed=`$execpath/renamer.py --in_tar $tar $renamer_opts`
+      renamed=$INCOMING_BIDS_DIR/$renamed
+      cp -v $tar $renamed
+      renamed_tars="$renamed_tars $renamed"
+  done
+  in_tar="$renamed_tars"
+fi 
 
 # 2. import into INCOMING_BIDS_DIR, but keep job files in INCOMING_LOG_DIR (so the job can clean up after itself)
 pushd $INCOMING_LOG_DIR

--- a/bin/renamer.py
+++ b/bin/renamer.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+import re
+import argparse
+import os
+
+parser = argparse.ArgumentParser(description='Launches JupyterLab in an interactive compute canada job, creating the required ssh tunnel.')
+
+parser.add_argument('--in_parse',help='Regular expression to parse subject (and session optionally) from PatientName (default: %(default)s)',required=True,
+                    default='(?:[\w]*)(?<=[Tt][Oo][Pp][Ss][Yy]_)(?P<subject>[A-Za-z0-9]+)_*(?P<session>[A-Za-z0-9]+)*')
+parser.add_argument('--in_tar',help='Tar filename',required=True)
+parser.add_argument('--out_reformat',help='Format string to rename output file (can use subject, session, pi, project, yyyymmdd, instance, hash, extension) (default: %(default)s)',
+                    default='{pi}_{project}_{yyyymmdd}_{subject}_{session}_{instance}.{hash}.{extension}')
+parser.add_argument('--default_session',help='If session not found, use this as default session')
+
+args = parser.parse_args()
+
+def renamer (tar, parse_patientname_regex, rename_format_string,default_session=None):
+
+    """
+    #patient_name = yyyy_mm_dd_{study}_{subject}[_{session}] 
+    patient_name = '?P<date>[\d]{4}_[\d]{2}_[\d]{2})'\
+                    '_(?P<study>[A-Za-z0-9]+)'\
+                    '_(?P<subject>[A-Za-z0-9]+)'\
+                    '_*(?P<session>[A-Za-z0-9]+)*',
+    
+    # input: search string for patient_name
+    #patient_name = *_{subject}[_{session}] 
+    patient_name = '(?:[\w]+)_(?P<subject>[A-Za-z0-9]+)_*(?P<session>[A-Za-z0-9]+)*'
+
+    # input: rename formatting string
+    #rename formatting string
+    rename_string = '{pi}_{project}_{yyyymmdd}_{subject}_{session}_{instance}.{hash}.{extension}'
+    """
+    
+    #define the search list (entries will be joined by underscores)
+    search_list = ['(?P<pi>[A-Za-z0-9]+)',
+                '(?P<project>[A-Za-z0-9]+)',
+                '(?P<yyyymmdd>[0-9]{8})',
+                '(?P<patient_name>(' + parse_patientname_regex + ')',
+                '(?P<instance>[0-9]+).(?P<hash>[0-9A-F]{8}).(?P<extension>tar(.gz)*)']
+
+    #do the search, and get the matching group terms as a dict
+    match_dict = re.search('_'.join(search_list),tar).groupdict()
+    #set default values, e.g. ensures session is set
+    if match_dict['session'] == None:
+        match_dict['session'] = default_session
+
+    #create renamed tarfile name
+    renamed = rename_format_string.format(**match_dict)
+    
+    return renamed
+
+
+basename = os.path.basename(args.in_tar)
+print(renamer(basename, args.in_parse, args.out_reformat,default_session=args.default_session))


### PR DESCRIPTION
Added ability to (optionally) automatically rename tar files in autobidsProcess. This allows more powerful regex matching of the PatientName to extract subject/session, and can be used to enforce a default session if none was provided.

Requires 3 new variables in autobids study cfg if being used:
- `RENAMER_PARSE_PATIENTNAME`: regex for parsing PatientName, needs the named groups: subject (and optionally session)
- `RENAMER_FORMAT_STRING`: output format for writing the tar file, can use the following variables:
  - pi
  - project
  - yyyymmdd
  - instance
  - hash 
  - extension
  - any named groups defined in the PatientName regex (e.g. subject or session)
And optionally:
- `RENAMER_DEFAULT_SESSION`: the default session to use, if session is not found in the PatientName

## Example: 
In this study config snippet (for TOPSY study), will rename the PatientName to {subject}_{session}, and use the default session 01 if a session isn't defined.

```
RENAMER_PARSE_PATIENTNAME='(?:[\w]*)(?<=[Tt][Oo][Pp][Ss][Yy]_)(?P<subject>[A-Za-z0-9]+)_*(?P<session>[A-Za-z0-9]+)*)'
RENAMER_FORMAT_STRING='{pi}_{project}_{yyyymmdd}_{subject}_{session}_{instance}.{hash}.{extension}'
RENAMER_DEFAULT_SESSION='01'
SUBJ_EXPR='{subject}_{session}'
```
